### PR TITLE
Use user access token instead of username/password

### DIFF
--- a/huggingface_auth.py
+++ b/huggingface_auth.py
@@ -164,7 +164,7 @@ def authorize_with_huggingface() -> HuggingFaceAuthorizer:
                 "You just need to give a ",
                 colored("'read'", attrs=['bold']),
                 "role to this access token." ,
-                "Don't forget to give a now explicit new to this access token like for example",
+                "Don't forget to give an explicit name to this access token like",
                 colored(f"'{organization_name}-{model_name}-collaborative-training'", attrs=['bold'])
                 ]
             print(*msg)

--- a/huggingface_auth.py
+++ b/huggingface_auth.py
@@ -86,7 +86,6 @@ class HuggingFaceAuthorizer(TokenAuthorizerBase):
                         'peer_public_key': self.local_public_key.to_bytes().decode(),
                     },
                 },
-                verify=False,  # FIXME: Update the expired API certificate
             )
 
             response.raise_for_status()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ nltk>=3.6.2
 sentencepiece
 aiohttp
 requests>=2.24.0
+termcolor


### PR DESCRIPTION
The use of login with username + password is now deprecated on the huggingface site. Instead, it is recommended to use user access token allowing applications to perform specific actions specified by the scope of permissions (read, write, or admin) granted. 

This PR therefore proposes changes to use this kind of access tokens.

Corresponding issue: training-transformers-together/training-transformers-together.github.io#7